### PR TITLE
Update app.R

### DIFF
--- a/LossSimulator/DisasterRiskPooling/app.R
+++ b/LossSimulator/DisasterRiskPooling/app.R
@@ -519,11 +519,12 @@ server <- function(input, output, session) {
     )
   })
 
-  # Create dynamic text to describe whether user data has been imported of or not
+  # Create dynamic text to describe whether user data has been imported or not
   output$manual_data_chosen_ui <-
     shiny::renderUI(
       {
-        if (is.null(input$ownFile) || !is.null(validate_upload())) {
+        #if (is.null(input$ownFile) || !is.null(validate_upload())) {
+        if (!is.null(validate_upload())) {
           fluidRow(
             column(
               11,


### PR DESCRIPTION
To resolve https://github.com/IDF-RMSG/DisasterRiskPooling/issues/34

I'm proposing to remove the condition "is.null(input$ownFile)" so the error message doesn't show before data has been uploaded.

Review needed @JPM-MaxInfo - especially whether the message still shows before manual input has been uploaded, because it has not yet been validated. In which case, do we remove the error message codeblock entirely?